### PR TITLE
fix ptrCast usage for Zig 0.12

### DIFF
--- a/src/kernel/main.zig
+++ b/src/kernel/main.zig
@@ -89,7 +89,7 @@ export var limine_hhdm_request: limine.HhdmRequest linksection(".limine_reqs") =
 export var limine_framebuffer_request: limine.FramebufferRequest linksection(".limine_reqs") = .{};
 
 fn draw_gui(fb: *limine.Framebuffer) void {
-    const pixels: [*]u8 = @ptrCast([*]u8, fb.address.?);
+    const pixels: [*]u8 = @as([*]u8, @ptrCast(fb.address.?));
     const bytes_per_pixel: u64 = @as(u64, fb.bpp) / 8;
     var y: u64 = 0;
     while (y < fb.height) : (y += 1) {


### PR DESCRIPTION
## Summary
- fix ptrCast usage for Zig 0.12 in framebuffer drawing

## Testing
- `zig fmt src/kernel/main.zig` *(fails: command not found)*
- `TOOLCHAIN_ZIG=./toolchain/zig/zig make build` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896a8d4cf3c8321981cdac092afb61d